### PR TITLE
implement --continue / -C

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,9 +121,6 @@ func main() {
 			body = &data
 		}
 
-		// Somewhere in here I need to add an if opts.resume, then set the range based on the filebytes on disk
-		// https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
-
 		req, err := http.NewRequest(opts.method, target, body)
 		if err != nil {
 			Status.Fatalf("Error: unable to create http %s request; %s\n", opts.method, err)

--- a/options.go
+++ b/options.go
@@ -192,10 +192,8 @@ func (o *Options) openOutputFile() *os.File {
 	var outputFile *os.File
 	if o.outputFilename != "" {
 		if o.resume {
-			if fileStat, err := os.Stat(o.outputFilename); err == nil {
-				if outputFile, err = os.OpenFile(o.outputFilename, os.O_APPEND|os.O_WRONLY, 0600); err != nil {
-					Status.Fatalf("Error: Unable to append to file '%s' for output\n", o.outputFilename)
-				}
+			if outputFile, err = os.OpenFile(o.outputFilename, os.O_APPEND|os.O_WRONLY, 0600); err != nil {
+				Status.Fatalf("Error: Unable to append to file '%s' for output\n", o.outputFilename)
 			}
 		}
 		if !o.resume {

--- a/options.go
+++ b/options.go
@@ -193,8 +193,6 @@ func (o *Options) openOutputFile() *os.File {
 	if o.outputFilename != "" {
 		if o.resume {
 			if fileStat, err := os.Stat(o.outputFilename); err == nil {
-				Status.Printf("Error: File '%s' exists\n", o.outputFilename)
-				Status.Printf("File size on disk is %v", fileStat.Size())
 				if outputFile, err = os.OpenFile(o.outputFilename, os.O_APPEND|os.O_WRONLY, 0600); err != nil {
 					Status.Fatalf("Error: Unable to append to file '%s' for output\n", o.outputFilename)
 				}


### PR DESCRIPTION
Checks for existence of file on disk, stats bytes, and forwards extra
`Range: bytes=N` header in req.

Server responds with Content-Range in resp, and download resumes
from bytemark specified.

Resolves #46