### PR TITLE
Dockerfile for a static kurly (~7MB image)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+
+FROM golang:1.8 as kurly
+
+RUN go get github.com/davidjpeacock/cli/...
+RUN go get github.com/alsm/ioprogress/...
+
+COPY . /go/src/github.com/davidjpeacock/kurly
+
+WORKDIR /go/src/github.com/davidjpeacock/kurly
+
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o kurly *.go \
+    && mv kurly /usr/local/bin/
+
+# ==================================================================================
+
+FROM scratch
+
+COPY --from=kurly /usr/local/bin/kurly /kurly
+
+ENTRYPOINT ["/kurly"]


### PR DESCRIPTION
The multi-stage syntax requires docker 17.05+
Thanks for the tool!