### PR TITLE
Add snap install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ From source you can simply:
 `kurly` can be installed through package management systems on the following platforms:
 
 * Arch Linux via Arch User Repos - `pacaur -S kurly` or `yaourt -S kurly`
+* Linux, using the [snap package](https://snapcraft.io/docs/core/install) - `snap install kurly`
 
 *If you're a package maintainer and you have prepared kurly for your OS of choice, please
 PR this section.*


### PR DESCRIPTION
I saw that @letozaf is publishing a snap package of kurly, which makes a one step install for Ubuntu, Solus, Fedora, Debian, and other Linux distros.