### PR TITLE
Issue #18 [Flag] -v

### DIFF
--- a/options.go
+++ b/options.go
@@ -181,6 +181,10 @@ func (o *Options) checkRedirect(req *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
 
+	if o.verbose {
+		Status.Println(" Ignoring the response body")
+		Status.Printf(" Issuing request to this URL : %s\n", req.URL)
+	}
 	return nil
 }
 

--- a/trace.go
+++ b/trace.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptrace"
+)
+
+type tracerStruct struct {
+	req         *http.Request
+	redirects   int
+	currentHost string
+}
+
+func (ts *tracerStruct) DNSStart(dnsinfo httptrace.DNSStartInfo) {
+	ts.currentHost = dnsinfo.Host
+}
+
+func (ts *tracerStruct) ConnectStart(network, addr string) {
+	hs, _, _ := net.SplitHostPort(addr)
+	Status.Printf("   Trying %s...\n", hs)
+}
+
+func (ts *tracerStruct) WroteHeaders() {
+	fmt.Fprintln(Outgoing, ts.req.Method, ts.req.URL.Path, ts.req.Proto)
+	for k, v := range ts.req.Header {
+		fmt.Fprintln(Outgoing, k, v)
+	}
+}
+
+func (ts *tracerStruct) ConnectDone(network, addr string, err error) {
+	Status.Println(" TCP_NODELAY set")
+	hs, port, _ := net.SplitHostPort(addr)
+	Status.Printf(" Connected to %s (%s) port %s (#%d)%s\n", ts.currentHost, hs, port, ts.redirects, ts.req.RequestURI)
+	ts.redirects += 1
+}
+
+func (ts *tracerStruct) GotConn(cinfo httptrace.GotConnInfo) {
+	if cinfo.Reused {
+		hs, port, _ := net.SplitHostPort(cinfo.Conn.RemoteAddr().String())
+		Status.Printf(" Re-using existing connection! (#%d) with host %s\n", ts.redirects-1, ts.currentHost)
+		Status.Printf(" Connected to %s (%s) port %s (#%d)%s\n", ts.currentHost, hs, port, ts.redirects, ts.req.RequestURI)
+	}
+}
+
+func NewClientTraceForRequest(req *http.Request) *httptrace.ClientTrace {
+	if req == nil {
+		Status.Fatal("cannot do a verbose trace for a empty request")
+	}
+
+	ts := &tracerStruct{req: req}
+
+	return &httptrace.ClientTrace{
+		ConnectStart: ts.ConnectStart,
+		ConnectDone:  ts.ConnectDone,
+		WroteHeaders: ts.WroteHeaders,
+		GotConn:      ts.GotConn,
+		DNSStart:     ts.DNSStart,
+	}
+}

--- a/trace.go
+++ b/trace.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptrace"
+	"strings"
 )
 
 type tracerStruct struct {
@@ -44,6 +46,41 @@ func (ts *tracerStruct) GotConn(cinfo httptrace.GotConnInfo) {
 	}
 }
 
+func (ts *tracerStruct) TLSHandshakeDone(cstate tls.ConnectionState, err error) {
+	if !cstate.HandshakeComplete {
+		Status.Printf(" TLS Handshake not completed")
+		return
+	}
+	var tlsversion, ciphersuite string
+	switch cstate.Version {
+	case tls.VersionSSL30:
+		tlsversion = "SSLv3"
+	case tls.VersionTLS10:
+		tlsversion = "TLSv1.0"
+	case tls.VersionTLS11:
+		tlsversion = "TLSv1.1"
+	case tls.VersionTLS12:
+		tlsversion = "TLSv1.2"
+	}
+
+	ciphersuite = getCipherSuiteString(cstate.CipherSuite)
+	Status.Printf(" APLN, server accepted to use %s", cstate.NegotiatedProtocol)
+	Status.Printf(" %s, TLS Handshake finished", tlsversion)
+	Status.Printf(" SSL connection using %s / %s", tlsversion, ciphersuite)
+	if len(cstate.PeerCertificates) > 0 {
+		cert := cstate.PeerCertificates[0]
+		Status.Println(" Server certificate:")
+		Status.Printf("  subject: CN=%s\n", cert.Subject.CommonName)
+		Status.Printf("  start date: %s\n", cert.NotBefore.Format("Mon, 02 Jan 2006 15:04:05 MST"))
+		Status.Printf("  expire date: %s\n", cert.NotAfter.Format("Mon, 02 Jan 2006 15:04:05 MST"))
+		Status.Printf("  issuer: C=%s; O=%s; CN=%s\n",
+			strings.Join(cert.Issuer.Country, " "),
+			strings.Join(cert.Issuer.Organization, " "),
+			cert.Issuer.CommonName)
+		Status.Printf("  SSL certificate verify ok.\n")
+	}
+}
+
 func NewClientTraceForRequest(req *http.Request) *httptrace.ClientTrace {
 	if req == nil {
 		Status.Fatal("cannot do a verbose trace for a empty request")
@@ -52,10 +89,61 @@ func NewClientTraceForRequest(req *http.Request) *httptrace.ClientTrace {
 	ts := &tracerStruct{req: req}
 
 	return &httptrace.ClientTrace{
-		ConnectStart: ts.ConnectStart,
-		ConnectDone:  ts.ConnectDone,
-		WroteHeaders: ts.WroteHeaders,
-		GotConn:      ts.GotConn,
-		DNSStart:     ts.DNSStart,
+		ConnectStart:     ts.ConnectStart,
+		ConnectDone:      ts.ConnectDone,
+		WroteHeaders:     ts.WroteHeaders,
+		GotConn:          ts.GotConn,
+		DNSStart:         ts.DNSStart,
+		TLSHandshakeDone: ts.TLSHandshakeDone,
 	}
+}
+
+func getCipherSuiteString(num uint16) string {
+	switch num {
+	case tls.TLS_RSA_WITH_RC4_128_SHA:
+		return "RSA-RC4-128-SHA"
+	case tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA:
+		return "RSA-3DES-EDE-CBC-SHA"
+	case tls.TLS_RSA_WITH_AES_128_CBC_SHA:
+		return "RSA-AES-128-CBC-SHA"
+	case tls.TLS_RSA_WITH_AES_256_CBC_SHA:
+		return "RSA-AES-256-CBC-SHA"
+	case tls.TLS_RSA_WITH_AES_128_CBC_SHA256:
+		return "RSA-AES-128-CBC-SHA256"
+	case tls.TLS_RSA_WITH_AES_128_GCM_SHA256:
+		return "RSA-AES-128-GCM-SHA256"
+	case tls.TLS_RSA_WITH_AES_256_GCM_SHA384:
+		return "RSA-AES-256-GCM-SHA384"
+	case tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA:
+		return "ECDHE-ECDSA-RC4-128-SHA"
+	case tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA:
+		return "ECDHE-ECDSA-AES-128-CBC-SHA"
+	case tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA:
+		return "ECDHE-ECDSA-AES-256-CBC-SHA"
+	case tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA:
+		return "ECDHE-RSA-RC4-128-SHA"
+	case tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA:
+		return "ECDHE-RSA-3DES-EDE-CBC-SHA"
+	case tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA:
+		return "ECDHE-RSA-AES-128-CBC-SHA"
+	case tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA:
+		return "ECDHE-RSA-AES-256-CBC-SHA"
+	case tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256:
+		return "ECDHE-ECDSA-AES-128-CBCSHA256"
+	case tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256:
+		return "ECDHE-RSA-AES-128-CBC-SHA256"
+	case tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:
+		return "ECDHE-RSA-AES-128-GCM-SHA256"
+	case tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:
+		return "ECDHE-ECDSA-AES-128-GCM-SHA256"
+	case tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:
+		return "ECDHE-RSA-AES-256-GCM-SHA384"
+	case tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:
+		return "ECDHE-ECDSA-AES-256-GCM-SHA384"
+	case tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305:
+		return "ECDHE-RSA-CHACHA20-POLY1305"
+	case tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305:
+		return "ECDHE-ECDSA-CHACHA20-POLY1305"
+	}
+	return "FALLBACK-SCSV"
 }


### PR DESCRIPTION
*An attempt to fix Issue #18.*
Added some extra logging support (basic TLS logging)
When `https://httpbin.org/redirect/1` fetched with `-L` and `-v` flags in kurly and cURL produced following output

### cURL
```
*   Trying 50.19.252.69...
* TCP_NODELAY set
* Connected to httpbin.org (50.19.252.69) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Client hello (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: CN=httpbin.org
*  start date: Nov 12 23:32:05 2017 GMT
*  expire date: Feb 10 23:32:05 2018 GMT
*  subjectAltName: host "httpbin.org" matched cert's "httpbin.org"
*  issuer: C=US; O=Let's Encrypt; CN=Let's Encrypt Authority X3
*  SSL certificate verify ok.
> GET /redirect/1 HTTP/1.1
> Host: httpbin.org
> User-Agent: curl/7.57.0
> Accept: */*
> 
< HTTP/1.1 302 FOUND
< Connection: keep-alive
< Server: meinheld/0.6.1
< Date: Fri, 29 Dec 2017 19:48:12 GMT
< Content-Type: text/html; charset=utf-8
< Content-Length: 215
< Location: /get
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Credentials: true
< X-Powered-By: Flask
< X-Processed-Time: 0.000591993331909
< Via: 1.1 vegur
< 
* Ignoring the response-body
* Connection #0 to host httpbin.org left intact
* Issue another request to this URL: 'https://httpbin.org/get'
* Found bundle for host httpbin.org: 0x562a11c7f650 [can pipeline]
* Re-using existing connection! (#0) with host httpbin.org
* Connected to httpbin.org (50.19.252.69) port 443 (#0)
> GET /get HTTP/1.1
> Host: httpbin.org
> User-Agent: curl/7.57.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Connection: keep-alive
< Server: meinheld/0.6.1
< Date: Fri, 29 Dec 2017 19:48:12 GMT
< Content-Type: application/json
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Credentials: true
< X-Powered-By: Flask
< X-Processed-Time: 0.000709056854248
< Content-Length: 214
< Via: 1.1 vegur
< 
{
  "args": {}, 
  "headers": {
    "Accept": "*/*", 
    "Connection": "close", 
    "Host": "httpbin.org", 
    "User-Agent": "curl/7.57.0"
  }, 
  "origin": "115.254.96.2", 
  "url": "https://httpbin.org/get"
}
* Connection #0 to host httpbin.org left intact
```

# kurly

```
*   Trying 50.19.252.69...
* TCP_NODELAY set
* Connected to httpbin.org (50.19.252.69) port 443 (#0)
* APLN, server accepted to use http/1.1
* TLSv1.2, TLS Handshake finished
* SSL connection using TLSv1.2 / ECDHE-RSA-AES-128-GCM-SHA256
* Server certificate:
*  subject: CN=httpbin.org
*  start date: Sun, 12 Nov 2017 23:32:05 UTC
*  expire date: Sat, 10 Feb 2018 23:32:05 UTC
*  issuer: C=US; O=Let's Encrypt; CN=Let's Encrypt Authority X3
*  SSL certificate verify ok.
> GET /redirect/1 HTTP/1.1
> User-Agent [Kurly/1.0]
> Accept [*/*]
> Host [httpbin.org]
* Ignoring the response body
* Issuing request to this URL : https://httpbin.org/get
* Re-using existing connection! (#0) with host httpbin.org
* Connected to httpbin.org (50.19.252.69) port 443 (#1)
> GET /redirect/1 HTTP/1.1
> User-Agent [Kurly/1.0]
> Accept [*/*]
> Host [httpbin.org]
< HTTP/1.1 200 OK
< X-Powered-By [Flask]
< X-Processed-Time [0.000689029693604]
< Content-Length [294]
< Via [1.1 vegur]
< Server [meinheld/0.6.1]
< Access-Control-Allow-Origin [*]
< Content-Type [application/json]
< Access-Control-Allow-Credentials [true]
< Connection [keep-alive]
< Date [Fri, 29 Dec 2017 19:48:46 GMT]
[<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<] 294 B/294 B
{
  "args": {}, 
  "headers": {
    "Accept": "*/*", 
    "Accept-Encoding": "gzip", 
    "Connection": "close", 
    "Host": "httpbin.org", 
    "Referer": "https://httpbin.org/redirect/1", 
    "User-Agent": "Kurly/1.0"
  }, 
  "origin": "115.254.96.2", 
  "url": "https://httpbin.org/get"
}
```

Also to be noted : the request headers are printed before making the request, now that is moved to the client trace mechanism so that it is done after the connection is made